### PR TITLE
changed payment plan to match SPC invoicing

### DIFF
--- a/tuition.html
+++ b/tuition.html
@@ -98,10 +98,7 @@ schools:
       options below.
     options:
     - title: Lubbock Coding Academy Payment Plan (Budget Option)
-      description: With our new payment plan, you can get started with Lubbock Coding
-        Academy for just $460 up-front. After you begin classes you’ll make bi-weekly
-        payments of $225 for 18-months, for a total program cost of $8,560. No interest
-        and no penalty for prepayment!
+      description: The entire program is $7960 but will be make in 4 payments of $1990 every other month.
       price_header: Details
       price: "$460"
       payment_deposit: "$225 bi-weekly payments"


### PR DESCRIPTION
With our new payment plan, you can get started with Lubbock Coding Academy for just $460 up-front. After you begin classes you’ll make bi-weekly payments of $225 for 18-months, for a total program cost of $8,560. No interest and no penalty for prepayment! 

>>

The entire program is $7960 but will be make in 4 payments of $1990 every other month.

8560 - 460 = 8100

$460 deposit
$810/monthly