### PR TITLE
Removed TypeForm from ACA Apply Page

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -461,7 +461,6 @@ isa_inputs:
             <div id="isa-questions" class="d-none col-12 p-0">
               {% include fields.html fields=page.isa_inputs %}
             </div>
-          {% endif %}
           <div class="my-4 d-flex flex-column align-items-center">
             <!-- htmllint preset="none" -->
             <button class="mb-4 btn cta-gradient hover-white text-white hover-white {% if school.inverted != true %}btn-round{% endif %} {{ include.class | liquify }}" >

--- a/apply.html
+++ b/apply.html
@@ -414,37 +414,6 @@ isa_inputs:
       {% endfor %}
     </div>
   </div>
-  {% if school.typeform_active == true %}
-  <div class="container mt-5 mb-5">
-    <div id="application"></div>
-      <script>
-        const typeform_id = '{{ school.typeform_application_id }}';
-        const setIframe = async () => {
-          const ip = await (await fetch('https://4runw89p71.execute-api.us-west-1.amazonaws.com/latest/ip')).json();
-          setTimeout(function() {
-            var hutkCookie = document.cookie.split(';').find(function(cookie) { 
-              return cookie.includes('hubspotutk')
-            });
-            if (hutkCookie) {
-              var hutk = hutkCookie.trim().split('=')[1];
-            }
-            const { title, baseURI, URL } = document;
-            document.querySelector('#application').innerHTML = (`
-              <iframe 
-                src="https://zollege.typeform.com/to/${typeform_id}#ip_address=${ip}&hutk=${hutk}&page_name=${title}&page_uri=${baseURI}&form_source_url=${URL}"
-                width="100%"
-                height="600"
-                scrolling="no"
-                style="border:none;overflow:hidden;border-radius:3px;"
-              >
-              </iframe>
-            `)
-          }, 2000);
-        }
-        setIframe(); 
-        </script>
-  </div>
-  {% else %}
   <div class="my-5 my-sm-10 px-4 p-lg-0 border mx-auto d-flex flex-column align-items-center">
       <h2 id="start-application" class="font-family-alt mt-5 mt-sm-10 mb-md-4 mb-sm-10 display-5 text-center col-12 col-sm-10">
         {{ page.heading }}


### PR DESCRIPTION
Removed this shitty form that stops people from applying. Thanks Zollege, for not advising us to remove it after you realized it didn't work for Medical & Dental. #Unity 

`{% if school.typeform_active == true %}
  <div class="container mt-5 mb-5">
    <div id="application"></div>
      <script>
        const typeform_id = '{{ school.typeform_application_id }}';
        const setIframe = async () => {
          const ip = await (await fetch('https://4runw89p71.execute-api.us-west-1.amazonaws.com/latest/ip')).json();
          setTimeout(function() {
            var hutkCookie = document.cookie.split(';').find(function(cookie) { 
              return cookie.includes('hubspotutk')
            });
            if (hutkCookie) {
              var hutk = hutkCookie.trim().split('=')[1];
            }
            const { title, baseURI, URL } = document;
            document.querySelector('#application').innerHTML = (`
              <iframe 
                src="https://zollege.typeform.com/to/${typeform_id}#ip_address=${ip}&hutk=${hutk}&page_name=${title}&page_uri=${baseURI}&form_source_url=${URL}"
                width="100%"
                height="600"
                scrolling="no"
                style="border:none;overflow:hidden;border-radius:3px;"
              >
              </iframe>
            `)
          }, 2000);
        }
        setIframe(); 
        </script>
  </div>
  {% else %}`